### PR TITLE
FIX unprocessable_entity when body is string

### DIFF
--- a/src/Fabs/Rest/Application.php
+++ b/src/Fabs/Rest/Application.php
@@ -48,7 +48,7 @@ class Application extends BaseApplication
     {
         if ($this->request_data == null) {
             $this->request_data = $this->request->getJsonRawBody(true);
-            if ($this->request_data === false) {
+            if ($this->request_data === false || !is_array($this->request_data)) {
                 $this->request_data = [];
             }
         }


### PR DESCRIPTION
This commit fixes the issue that when body is string, unprocessable entity error does not occur