### PR TITLE
FIX mapping

### DIFF
--- a/src/Fabs/Rest/Models/MapModel.php
+++ b/src/Fabs/Rest/Models/MapModel.php
@@ -26,7 +26,7 @@ class MapModel extends ServiceBase
 
     public function __construct($method_name, $uri, $function_name)
     {
-        $this->method_name = strtolower($method_name);
+        $this->method_name = strtoupper($method_name);
         $this->uri = $uri;
         $this->function_name = $function_name;
     }


### PR DESCRIPTION
As in `\Phalcon\Http\Request.php` file `public final function getMethod()` method's comments, 

> The method is always an uppercased string.

This commit should fix mapping problems.